### PR TITLE
fix: resolveAssetSource expects a number or ImageSource object

### DIFF
--- a/src/index.native.js
+++ b/src/index.native.js
@@ -255,6 +255,9 @@ export default class Audio {
       this._source = v
       return
     }
+    if(typeof v === 'string') {
+      v = { uri: v }
+    }
     this._source = resolveAssetSource(v)
     if(this._source.uri.startsWith('file://')) {
       const path = this._source.uri.substr('file://'.length)


### PR DESCRIPTION
[Image.resolveAssetSource(source)](https://facebook.github.io/react-native/docs/image#resolveassetsource)

addresses yusukeshibata/react-native-audio-polyfill#7